### PR TITLE
fix: Add graceful handling of missing `extension`

### DIFF
--- a/DocRefParser.py
+++ b/DocRefParser.py
@@ -54,7 +54,10 @@ for file in files:
             encounter_id = data['context']['encounter'][0]['reference']
 
             ## get the top-level FHIR extension element
-            data = data['extension']
+            try:
+                data = data['extension']
+            except KeyError:
+                continue
 
             for item in data:
                 if item['url'] == 'http://healthlake.amazonaws.com/aws-cm/':


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Script fails if DocumentReference resource does not have `extension` element. 
This fix catches that error condition and continues processing subsequent resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
