### PR TITLE
fix: reduce number of patients to contain NLP cost

### DIFF
--- a/generate_synthetic_data.sh
+++ b/generate_synthetic_data.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-./run_synthea -c synthea.properties -m congestive_heart_failure:breast_cancer -p 5000 -s 0 -cs 0 -r 20210401
+./run_synthea -c synthea.properties -m congestive_heart_failure:breast_cancer -p 500 -s 0 -cs 0 -r 20210401
 
 find ./output -name "*.ndjson" -size +50000000c -print | while read file; do
   fn=$(basename -s .ndjson ${file})


### PR DESCRIPTION
*Resolves #6*

*Description of changes:*
Reduce number of patients to generate set of synthetic data from 5000 to 500 to reduce associated cost of processing DocumentReference resources through Amazon HealthLake's NLP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
